### PR TITLE
Blocks breaking armour stand if build is disabled.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.noodles</groupId>
     <artifactId>buildmode</artifactId>
-    <version>3.4</version>
+    <version>3.5</version>
     <packaging>jar</packaging>
 
     <name>BuildModeBGHD</name>

--- a/src/main/java/me/noodles/buildmode/events/Events.java
+++ b/src/main/java/me/noodles/buildmode/events/Events.java
@@ -3,6 +3,9 @@ package me.noodles.buildmode.events;
 import org.bukkit.entity.*;
 import org.bukkit.event.*;
 import org.bukkit.event.block.*;
+import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntitySpawnEvent;
 import org.bukkit.event.player.*;
 
 import me.noodles.buildmode.main.MainBuildMode;
@@ -52,7 +55,33 @@ public class Events implements Listener
         }
         e.setCancelled(true);
     }
-    
+
+    @EventHandler
+    public void onArmourStandBreak(EntityDamageByEntityEvent e) {
+        if (e.getDamager() instanceof Player) {
+            final Player p = (Player) e.getDamager();
+            if (e.getEntityType().equals(EntityType.ARMOR_STAND)) {
+                if (!p.getGameMode().name().equals("CREATIVE") || MainBuildMode.playerlist.contains(p)) {
+                    return;
+                }
+                e.setCancelled(true);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onArmourStandBreakSurvival(EntityDamageByEntityEvent e) {
+        if (e.getDamager() instanceof Player) {
+            final Player p = (Player) e.getDamager();
+            if (e.getEntityType().equals(EntityType.ARMOR_STAND)) {
+                if (!p.getGameMode().name().equals("SURVIVAL") || MainBuildMode.playerlist.contains(p)) {
+                    return;
+                }
+                e.setCancelled(true);
+            }
+        }
+    }
+
     @EventHandler
     public void onPlayerLeave(PlayerQuitEvent e) {
         final Player p = e.getPlayer();

--- a/src/main/java/me/noodles/buildmode/utils/Settings.java
+++ b/src/main/java/me/noodles/buildmode/utils/Settings.java
@@ -6,6 +6,6 @@ public class Settings {
     public static String DEVELOPER_URL = "https://bghddevelopment.com";
     public static String PLUGIN_URL = "https://spigotmc.org/resources/39103";
     public static String SUPPORT_DISCORD_URL = "https://bghddevelopment.com/discord";
-    public static String VERSION = "3.4";
+    public static String VERSION = "3.5";
     public static String NAME = "BuildMode";
 }


### PR DESCRIPTION
Change Log:

- Now blocks breaking armour stand if build is disabled. ([https://feedback.bghddevelopment.com/d/350-buildmode](https://feedback.bghddevelopment.com/d/350-buildmode))
- Updated version from 3.4 to 3.5 ready for release.